### PR TITLE
Enforces C++  standard requirement and adds minimum GCC version

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python_version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python_version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         pip_install_flag: ["none", "editable", "user"]
 
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,12 @@ project(RTModel LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    set(MINIMUM_GCC_VERSION "9.0")
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS MINIMUM_GCC_VERSION)
+        message(FATAL_ERROR "GCC must be ${MINIMUM_GCC_VERSION} or greater.")
+    endif()
+endif()
 
 # Build executables
 # =================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.19)
 project(RTModel LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Build executables
 # =================


### PR DESCRIPTION
Adds an enforcement for the C++ standard requirement of the compiler. Unfortunately, earlier versions of GCC can still technically meet these requirements with special linking, so this does not exclude some GCC versions. So the PR also includes a check that, if the user is using GCC, that the version of GCC is recent enough not to require these special linkings.